### PR TITLE
Better polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,66 @@
 
 Simple Rust Actors
 
+# API
+
+## Block
+
+> TODO,
+
+## Poll
+
+1. Load the data that you want to sent to the actor
+2. Get a Promise back
+3. Poll the Promise till data is received
+
+```rust
+let actor_ref = todo!("Get your actor ref");
+let mut promise = actor_ref.as_poll(request);
+loop {
+  let _result = promise.poll_once();
+  if promise.get().is_some() {
+    // Data has been received
+    break;
+  }
+}
+let data: Option<&Response> = promise.get();
+```
+
+```rust
+// Another way to do the same thing
+let actor_ref = todo!("Get your actor ref");
+let mut promise = actor_ref.as_poll(request);
+loop {
+  let result = promise.poll_once();
+  if result.is_ok() {
+    if matches!(res.unwrap(), ActorRefPollInfo::Complete) {
+        break;
+    }
+  }
+}
+let data: Option<&Response> = promise.get();
+```
+
+```mermaid
+---
+title: Polling good states
+---
+stateDiagram-v2
+  Start --> RequestSent: RequestSent
+  Start --> Start: RequestQueueFull
+  RequestSent --> RequestSent: ResponseQueueEmpty
+  RequestSent --> End(ok): Complete
+```
+
+```mermaid
+---
+title: Polling errors
+---
+stateDiagram-v2
+  Start --> End(error): ActorShutdown
+  RequestSent --> End(error): ActorInternalError
+```
+
 ## Notes
 
 - `crossbeam-channel` has been used purely for its `select!` macro

--- a/threaded_actor/src/common.rs
+++ b/threaded_actor/src/common.rs
@@ -15,3 +15,30 @@ impl std::fmt::Display for ActorError {
 }
 
 impl std::error::Error for ActorError {}
+
+#[cfg(test)]
+pub mod common_test_actors {
+    use super::*;
+    use std::{thread, time::Duration};
+
+    pub struct Ping {
+        pub delay: Option<Duration>,
+    }
+
+    impl ActorHandler<(), ()> for Ping {
+        fn handle(&mut self, _request: ()) -> () {
+            if let Some(d) = self.delay {
+                thread::sleep(d);
+            }
+            ()
+        }
+    }
+
+    pub struct SimulateThreadCrash;
+
+    impl ActorHandler<(), ()> for SimulateThreadCrash {
+        fn handle(&mut self, _request: ()) -> () {
+            panic!("Simulate thread crash");
+        }
+    }
+}

--- a/threaded_actor/src/common.rs
+++ b/threaded_actor/src/common.rs
@@ -1,0 +1,17 @@
+pub trait ActorHandler<Req, Res> {
+    fn handle(&mut self, request: Req) -> Res;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ActorError {
+    ActorShutdown,
+    ActorInternalError,
+}
+
+impl std::fmt::Display for ActorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        format!("{:?}", self).fmt(f)
+    }
+}
+
+impl std::error::Error for ActorError {}

--- a/threaded_actor/src/lib.rs
+++ b/threaded_actor/src/lib.rs
@@ -123,28 +123,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common_test_actors::{Ping, SimulateThreadCrash};
     use std::time::{Duration, Instant};
-
-    struct Ping {
-        delay: Option<Duration>,
-    }
-
-    impl ActorHandler<(), ()> for Ping {
-        fn handle(&mut self, _request: ()) -> () {
-            if let Some(d) = self.delay {
-                thread::sleep(d);
-            }
-            ()
-        }
-    }
-
-    struct SimulateThreadCrash;
-
-    impl ActorHandler<(), ()> for SimulateThreadCrash {
-        fn handle(&mut self, _request: ()) -> () {
-            panic!("Simulate thread crash");
-        }
-    }
 
     #[test]
     fn test_ping() {

--- a/threaded_actor/src/lib.rs
+++ b/threaded_actor/src/lib.rs
@@ -124,24 +124,16 @@ where
 mod tests {
     use super::*;
     use crate::common_test_actors::{Ping, SimulateThreadCrash};
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
 
     #[test]
     fn test_ping() {
         let actor = Actor::new(2, Ping { delay: None });
         let actor_ref = actor.get_user_actor_ref();
 
-        let prev = Instant::now();
+        let now = Instant::now();
         let _ = actor_ref.block(());
-        let current = Instant::now();
-
-        println!(
-            "Current: {:?} Prev: {:?} Diff: {:?}, Elapsed: {:?}",
-            current,
-            prev,
-            current.duration_since(prev),
-            prev.elapsed()
-        );
+        println!("Elapsed: {:?}", now.elapsed());
 
         let res = actor
             .get_command_actor_ref()

--- a/threaded_actor/src/lib.rs
+++ b/threaded_actor/src/lib.rs
@@ -151,36 +151,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ping_poll() {
-        let actor = Actor::new(2, Ping { delay: None });
-        let actor_ref = actor.get_user_actor_ref();
-
-        let prev: Instant = Instant::now();
-        let mut promise = actor_ref.as_poll(());
-        loop {
-            let res = promise.poll_once();
-            if matches!(res.unwrap(), ActorRefPollInfo::Complete) {
-                break;
-            }
-        }
-        let current = Instant::now();
-
-        println!(
-            "Current: {:?} Prev: {:?} Diff: {:?}, Elapsed: {:?}",
-            current,
-            prev,
-            current.duration_since(prev),
-            prev.elapsed()
-        );
-
-        let res = actor
-            .get_command_actor_ref()
-            .block(ActorCommandReq::Shutdown);
-        assert!(matches!(res.unwrap(), ActorCommandRes::Shutdown));
-        assert!(actor.handle.join().unwrap().is_ok());
-    }
-
-    #[test]
     fn test_actor_multiple_messages() {
         let actor = Actor::new(1, Ping { delay: None });
         let actor_ref = actor.get_user_actor_ref();
@@ -191,37 +161,6 @@ mod tests {
         let _pong1 = actor_ref1.block(());
         let _pong2 = actor_ref2.block(());
 
-        let res = actor
-            .get_command_actor_ref()
-            .block(ActorCommandReq::Shutdown);
-        assert!(matches!(res.unwrap(), ActorCommandRes::Shutdown));
-        assert!(actor.handle.join().unwrap().is_ok());
-    }
-
-    #[test]
-    fn test_actor_queue_full() {
-        let actor = Actor::new(
-            1,
-            Ping {
-                delay: Some(Duration::from_secs(5)),
-            },
-        );
-        let actor_ref1 = actor.get_user_actor_ref();
-        let actor_ref2 = actor.get_user_actor_ref();
-
-        // Sends in queue
-        let mut promise1 = actor_ref1.as_poll(());
-        let res1 = promise1.poll_once();
-        assert!(res1.is_ok());
-        assert!(matches!(res1.unwrap(), ActorRefPollInfo::RequestSent));
-
-        // Queue is full
-        let mut promise2 = actor_ref2.as_poll(());
-        let res2 = promise2.poll_once();
-        assert!(res2.is_ok());
-        assert!(matches!(res2.unwrap(), ActorRefPollInfo::RequestQueueFull));
-
-        // Shutdown
         let res = actor
             .get_command_actor_ref()
             .block(ActorCommandReq::Shutdown);
@@ -246,23 +185,6 @@ mod tests {
     }
 
     #[test]
-    fn test_actor_send_after_shutdown_with_poll() {
-        let actor = Actor::new(1, Ping { delay: None });
-        let actor_ref = actor.get_user_actor_ref();
-
-        let res = actor
-            .get_command_actor_ref()
-            .block(ActorCommandReq::Shutdown);
-        assert!(matches!(res.unwrap(), ActorCommandRes::Shutdown));
-        assert!(actor.handle.join().unwrap().is_ok());
-
-        let mut promise = actor_ref.as_poll(());
-        let result = promise.poll_once();
-        assert!(result.is_err());
-        assert!(matches!(result.err().unwrap(), ActorError::ActorShutdown));
-    }
-
-    #[test]
     fn test_actor_bad_behavior_with_blocking() {
         let actor = Actor::new(1, SimulateThreadCrash);
         let actor_ref = actor.get_user_actor_ref();
@@ -270,23 +192,6 @@ mod tests {
         assert!(res.is_err());
         assert!(matches!(res.err().unwrap(), ActorError::ActorInternalError));
 
-        let result = actor.handle.join();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_actor_bad_behavior_with_poll() {
-        let actor = Actor::new(1, SimulateThreadCrash);
-        let actor_ref = actor.get_user_actor_ref();
-
-        let mut promise = actor_ref.as_poll(());
-        loop {
-            let result = promise.poll_once();
-            if let Err(e) = result {
-                assert!(matches!(e, ActorError::ActorInternalError));
-                break;
-            }
-        }
         let result = actor.handle.join();
         assert!(result.is_err());
     }

--- a/threaded_actor/src/poll.rs
+++ b/threaded_actor/src/poll.rs
@@ -1,0 +1,104 @@
+use crossbeam::channel::{self, Receiver, Sender, TryRecvError, TrySendError};
+
+use crate::ActorError;
+
+enum ActorRefPollState<Res> {
+    Start,                      // Try to send the request to Actor
+    RequestSent(Receiver<Res>), // Request sent successfully, waiting for response from Actor
+    End(Result<ActorRefPollInfo, ActorError>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ActorRefPollInfo {
+    RequestSent,
+    RequestQueueFull,
+    ResponseQueueEmpty,
+    Complete,
+}
+
+pub struct ActorRefPollPromise<Req, Res> {
+    req: Option<Req>,
+    channel: Option<(Sender<Res>, Receiver<Res>)>,
+    res: Option<Res>,
+    tx: Sender<(Req, Sender<Res>)>,
+    state: ActorRefPollState<Res>,
+}
+
+impl<Req, Res> ActorRefPollPromise<Req, Res> {
+    pub fn new(req: Req, tx: Sender<(Req, Sender<Res>)>) -> Self {
+        Self {
+            req: Some(req),
+            channel: Some(channel::bounded(1)),
+            res: None,
+            tx,
+            state: ActorRefPollState::Start,
+        }
+    }
+
+    pub fn is_ready() -> bool {
+        todo!()
+    }
+
+    pub fn get(&self) -> Option<&Req> {
+        todo!()
+    }
+
+    pub fn get_mut(&mut self) -> Option<&mut Req> {
+        todo!()
+    }
+
+    pub fn take(self) -> Option<Req> {
+        todo!()
+    }
+
+    /// Periodic polling for actions to be performed
+    /// Should be polled as frequently as possible
+    pub fn poll_once(&mut self) -> Result<ActorRefPollInfo, ActorError> {
+        match &self.state {
+            ActorRefPollState::Start => {
+                let (tx, rx) = self.channel.take().unwrap();
+                match self.tx.try_send((self.req.take().unwrap(), tx)) {
+                    Ok(_) => {
+                        self.state = ActorRefPollState::RequestSent(rx);
+                        Ok(ActorRefPollInfo::RequestSent)
+                    }
+                    Err(TrySendError::Full((r, t))) => {
+                        // Same state
+                        self.req = Some(r);
+                        self.channel = Some((t, rx));
+                        Ok(ActorRefPollInfo::RequestQueueFull)
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        let result = Err(ActorError::ActorShutdown);
+                        self.state = ActorRefPollState::End(result);
+                        result
+                    }
+                }
+            }
+            ActorRefPollState::RequestSent(rx) => {
+                //
+                match rx.try_recv() {
+                    Ok(data) => {
+                        let result = Ok(ActorRefPollInfo::Complete);
+                        self.res = Some(data);
+                        self.state = ActorRefPollState::End(result);
+                        result
+                    }
+                    Err(TryRecvError::Empty) => {
+                        // Same state
+                        Ok(ActorRefPollInfo::ResponseQueueEmpty)
+                    }
+                    Err(TryRecvError::Disconnected) => {
+                        let result = Err(ActorError::ActorInternalError);
+                        self.state = ActorRefPollState::End(result);
+                        result
+                    }
+                }
+            }
+            ActorRefPollState::End(reason) => {
+                // Do nothing
+                *reason
+            }
+        }
+    }
+}

--- a/threaded_actor/src/poll.rs
+++ b/threaded_actor/src/poll.rs
@@ -102,3 +102,109 @@ impl<Req, Res> ActorRefPollPromise<Req, Res> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::*;
+    use crate::{
+        common_test_actors::{Ping, SimulateThreadCrash},
+        Actor, ActorCommandReq, ActorCommandRes,
+    };
+
+    #[test]
+    fn test_ping_poll() {
+        let actor = Actor::new(2, Ping { delay: None });
+        let actor_ref = actor.get_user_actor_ref();
+
+        let prev: Instant = Instant::now();
+        let mut promise = actor_ref.as_poll(());
+        loop {
+            let res = promise.poll_once();
+            if matches!(res.unwrap(), ActorRefPollInfo::Complete) {
+                break;
+            }
+        }
+        let current = Instant::now();
+
+        println!(
+            "Current: {:?} Prev: {:?} Diff: {:?}, Elapsed: {:?}",
+            current,
+            prev,
+            current.duration_since(prev),
+            prev.elapsed()
+        );
+
+        let res = actor
+            .get_command_actor_ref()
+            .block(ActorCommandReq::Shutdown);
+        assert!(matches!(res.unwrap(), ActorCommandRes::Shutdown));
+        assert!(actor.handle.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn test_actor_queue_full() {
+        let actor = Actor::new(
+            1,
+            Ping {
+                delay: Some(Duration::from_secs(5)),
+            },
+        );
+        let actor_ref1 = actor.get_user_actor_ref();
+        let actor_ref2 = actor.get_user_actor_ref();
+
+        // Sends in queue
+        let mut promise1 = actor_ref1.as_poll(());
+        let res1 = promise1.poll_once();
+        assert!(res1.is_ok());
+        assert!(matches!(res1.unwrap(), ActorRefPollInfo::RequestSent));
+
+        // Queue is full
+        let mut promise2 = actor_ref2.as_poll(());
+        let res2 = promise2.poll_once();
+        assert!(res2.is_ok());
+        assert!(matches!(res2.unwrap(), ActorRefPollInfo::RequestQueueFull));
+
+        // Shutdown
+        let res = actor
+            .get_command_actor_ref()
+            .block(ActorCommandReq::Shutdown);
+        assert!(matches!(res.unwrap(), ActorCommandRes::Shutdown));
+        assert!(actor.handle.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn test_actor_send_after_shutdown_with_poll() {
+        let actor = Actor::new(1, Ping { delay: None });
+        let actor_ref = actor.get_user_actor_ref();
+
+        let res = actor
+            .get_command_actor_ref()
+            .block(ActorCommandReq::Shutdown);
+        assert!(matches!(res.unwrap(), ActorCommandRes::Shutdown));
+        assert!(actor.handle.join().unwrap().is_ok());
+
+        let mut promise = actor_ref.as_poll(());
+        let result = promise.poll_once();
+        assert!(result.is_err());
+        assert!(matches!(result.err().unwrap(), ActorError::ActorShutdown));
+    }
+
+    #[test]
+    fn test_actor_bad_behavior_with_poll() {
+        let actor = Actor::new(1, SimulateThreadCrash);
+        let actor_ref = actor.get_user_actor_ref();
+
+        let mut promise = actor_ref.as_poll(());
+        loop {
+            let result = promise.poll_once();
+            if let Err(e) = result {
+                assert!(matches!(e, ActorError::ActorInternalError));
+                break;
+            }
+        }
+        let result = actor.handle.join();
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
- Renamed to ActorRefPollPromise (non-clonable)
- More memory efficient (avoids unnecessary channel creation/destruction and stores requests temporarily in Option types)
- See `ActorRefPollPromise`